### PR TITLE
Fixing deprecation warning for gcd function

### DIFF
--- a/anti_lib.py
+++ b/anti_lib.py
@@ -318,7 +318,7 @@ class Polygon(RawFraction):
         if D == 0:
             raise ValueError('fraction denominator is a multiple '
                              'of the numerator')
-        self.parts = fractions.gcd(N, D)
+        self.parts = math.gcd(N, D)
         self.N = N // self.parts
         self.D = D // self.parts
 

--- a/anti_lib_progs/geodesic.py
+++ b/anti_lib_progs/geodesic.py
@@ -207,7 +207,7 @@ def class_type(val_str):
                     ' class pattern values cannot both be 0')
             pat.append(num)
 
-        rep = fractions.gcd(*pat)
+        rep = math.gcd(*pat)
         pat = [pat_num//rep for pat_num in pat]
         pat.append(rep)
 

--- a/anti_lib_progs/spiro.py
+++ b/anti_lib_progs/spiro.py
@@ -36,7 +36,7 @@ def spiro(num_teeth_fixed, num_teeth_move, height, num_segs, outfile):
     height = height*D/N
     num_segs = num_segs
 
-    turns = D/fractions.gcd(N, D)
+    turns = D/math.gcd(N, D)
     print('OFF\n{} 1 0'.format(num_segs), file=outfile)
 
     for i in range(num_segs):

--- a/anti_lib_progs/str_art.py
+++ b/anti_lib_progs/str_art.py
@@ -60,7 +60,7 @@ def main():
     N = args.factor.numerator
     D = args.factor.denominator
     pins = args.num_pins
-    turns = N / fractions.gcd(N, D)
+    turns = N / math.gcd(N, D)
     strings = turns*pins
     print('OFF\n{} {} 0'.format(pins, strings), file=args.outfile)
 


### PR DESCRIPTION
Replacing fractions.gcd() with math.gcd() to avoid deprecation warning.